### PR TITLE
Bumping to OpenTracing 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-opentracing/compare/0.1.2...HEAD
 
+### Changed
+
+-   Moved to OpenTracing 2 API
+-   [BREAKING CHANGE] this control does not expose spans as explicit properties
+    of the tracer any longer. This was due to a limitation of some of the
+    Open Tracing clients (namely Jaeger). Now these clients have been updated
+    to the newer version, this is not needed anymore. You can use the
+    active span of the tracer as expected. This only breaks if you accessed
+    directly those properties.
+
 ### Added
 
 -   Marked with `error:true` deviated hypotheses and failed activities

--- a/README.md
+++ b/README.md
@@ -31,15 +31,18 @@ Currently, this extension only provides control support to send traces to
 your provider during the execution of the experiment. It does not yet expose
 any probes or actions per-se.
 
-To use this control, add the following section to your experiment, at the
-top-level:
+### Declare within the experiment
+
+To use this control, you can declare it on a per experiment basis like this:
+
 
 ```json
 {
     "configuration": {
         "tracing_provider": "jaeger",
         "tracing_host": "127.0.0.1",
-        "tracing_port": 6831
+        "tracing_port": 6831,
+        "tracing_propagation": "b3"
     },
     "controls": [
         {
@@ -54,60 +57,64 @@ top-level:
 ```
 
 This will automatically create a [Jaeger][] client to emit traces onto the
-address `127.0.0.1:6831`.
+address `127.0.0.1:6831` (over UDP).
 
+### Declare within the settings
+
+You may also declare the control to be applied to all experiments by declaring
+the control from within the [Chaos Toolkit settings file][ctksettings]:
+
+```yaml
+controls:
+  opentracing:
+    provider:
+      type: python
+      module: chaostracing.control
+      arguments:
+        provider: jaeger
+        host: 127.0.0.1
+        port: 6831
+        propagation: b3
+```
+
+[ctksettings]: https://docs.chaostoolkit.org/reference/usage/cli/#configure-the-chaos-toolkit
 [jaeger]: https://www.jaegertracing.io/
 
-### Use from other extensions
+## Send traces from other extensions
 
-You may also access the tracer from other extensions as follows:
-
-```python
-import opentracing
-
-def some_function(...):
-    opentracing.tracer
-```
-
-As not all Open Tracing providers support yet to fetch the active span from
-the tracer (Open Tracing 2 specification), we attach the following attributes
-to the tracer instance:
-
-```python
-tracer.experiment_span  # span during the lifetime of the experiment
-tracer.hypothesis_span  # span during the lifetime of the hypothesis
-tracer.method_span  # span during the lifetime of the method
-tracer.rollback_span  # span during the lifetime of the rollback
-tracer.activity_span  # span during the lifetime of an activity
-```
+You may also access the tracer from other extensions as follows.
 
 For instance, assuming you have an extension that makes a HTTP call you want
 to trace specifically, you could do this from your extension's code:
 
+
 ```python
-import opentracing
+from chaoslib import Configuration, Secrets
 import requests
+import opentracing
 
-def my_activity(...):
-    headers = {}
+def some_function(configuration: Configuration, secrets: Secrets):
+    tracer = opentracing.global_tracer()
+    scope = tracer.scope_manager.active()
+    parent = scope.span
 
-    tracer = opentracing.tracer
-    parent_span = tracer.activity_span
-    span = tracer.start_span("my-inner-span", child_of=parent_span)
-    span.set_tag('http.method','GET')
-    span.set_tag('http.url', url)
-    span.set_tag('span.kind', 'client')
-    span.tracer.inject(span, 'http_headers', headers)
+    with tracer.start_span("call-service1", child_of=parent) as span:
+        span.set_tag('http.method','GET')
+        span.set_tag('http.url', url)
+        span.set_tag('span.kind', 'client')
+        span.tracer.inject(span, 'http_headers', headers)
 
-    r = requests.get(url, headers=headers)
-
-    span.set_tag('http.status_code', r.status_code)
-    span.finish()
+        r = requests.get(url, headers=headers)
+        span.set_tag('http.status_code', r.status_code)
 ```
 
 Because the opentracing exposes a noop tracer when non has been initialized,
 it should be safe to have that code in your extensions without having to
 determine if the extension has been enabled in the experiment.
+
+Please note that, Open Tracing scope cannot be shared across threads
+(while spans can). So, when running this in a background activity, the tracer
+will not actually be set to the one that was initialized.
 
 ## Open Tracing Provider Support
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-chaostoolkit-lib>=1.0.0rc1
+chaostoolkit-lib~=1.7
 logzero
-opentracing
+opentracing~=2.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from chaoslib.types import Activity, Configuration, Experiment, Hypothesis
 import opentracing
 import pytest
 
-from chaostracing.control import configure_control, cleanup_control, local
+from chaostracing.control import configure_control, cleanup_control
 
 @pytest.fixture
 def configuration() -> Configuration:
@@ -14,8 +14,8 @@ def configuration() -> Configuration:
 @pytest.fixture
 def tracer(configuration: Configuration) -> opentracing.Tracer:
     try:
-        configure_control(configuration)
-        yield local.tracer
+        tracer = configure_control(configuration)
+        yield tracer
     finally:
         cleanup_control()
 

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -5,89 +5,27 @@ from chaoslib.types import Activity, Configuration, Experiment, Hypothesis
 import opentracing
 import pytest
 
-from chaostracing.control import local, cleanup_control, configure_control, \
+from chaostracing.control import cleanup_control, configure_control, \
     before_experiment_control, after_experiment_control, \
     before_hypothesis_control, after_hypothesis_control, \
     before_method_control, after_method_control, before_rollback_control, \
     after_rollback_control, before_activity_control, after_activity_control
 
 
-def test_create_tracer(configuration: Configuration):
-    assert getattr(local, "tracer", None) is None
-    configure_control(configuration)
-
-    tracer = getattr(local, "tracer", None)
+def test_create_noop_tracer(configuration: Configuration):
+    assert opentracing.is_global_tracer_registered() is False
+    tracer = configure_control()
+    assert opentracing.is_global_tracer_registered() is True
     assert isinstance(tracer, opentracing.Tracer)
+    assert tracer == opentracing.global_tracer()
 
 
 def test_cleanup_control(configuration: Configuration):
-    tracer = local.tracer
-    assert isinstance(tracer, opentracing.Tracer)
+    tracer = opentracing.global_tracer()
+    span = tracer.start_active_span('boom')
+    scope = tracer.scope_manager.active
+    assert scope is not None
 
-    cleanup_control()
-    assert getattr(local, "tracer", None) is None
-
-
-def test_before_experiment_control(tracer, experiment: Experiment):
-    assert tracer.experiment_span is None
-    before_experiment_control(experiment)
-    assert tracer.experiment_span is not None
-
-
-def test_after_experiment_control(tracer, experiment: Experiment):
-    before_experiment_control(experiment)
-    assert tracer.experiment_span is not None
-    after_experiment_control(experiment, state={})
-    assert tracer.experiment_span is None
-
-
-def test_before_hypothesis_control(tracer, hypothesis: Hypothesis):
-    assert tracer.hypothesis_span is None
-    before_hypothesis_control(hypothesis)
-    assert tracer.hypothesis_span is not None
-
-
-def test_after_hypothesis_control(tracer, hypothesis: Hypothesis):
-    before_hypothesis_control(hypothesis)
-    assert tracer.hypothesis_span is not None
-    after_hypothesis_control(hypothesis, state={})
-    assert tracer.hypothesis_span is None
-
-
-def test_before_method_control(tracer, experiment: Experiment):
-    assert tracer.method_span is None
-    before_method_control(experiment)
-    assert tracer.method_span is not None
-
-
-def test_after_method_control(tracer, experiment: Experiment):
-    before_method_control(experiment)
-    assert tracer.method_span is not None
-    after_method_control(experiment, state={})
-    assert tracer.method_span is None
-
-
-def test_before_rollback_control(tracer, experiment: Experiment):
-    assert tracer.rollback_span is None
-    before_rollback_control(experiment)
-    assert tracer.rollback_span is not None
-
-
-def test_after_method_control(tracer, experiment: Experiment):
-    before_rollback_control(experiment)
-    assert tracer.rollback_span is not None
-    after_rollback_control(experiment, state={})
-    assert tracer.rollback_span is None
-
-
-def test_before_activity_control(tracer, activity: Activity):
-    assert tracer.activity_span is None
-    before_activity_control(activity)
-    assert tracer.activity_span is not None
-
-
-def test_after_activity_control(tracer, activity: Activity):
-    before_activity_control(activity)
-    assert tracer.activity_span is not None
-    after_activity_control(activity, state={})
-    assert tracer.activity_span is None
+    with patch.object(scope, 'close') as close:
+        cleanup_control()
+        assert close.call_count == 1


### PR DESCRIPTION
Now that more OpenTracng clients support Open Tracing 2, it is time to move to it.

This will remove the following attributes on the `tracer`:

```
tracer.experiment_span
tracer.hypothesis_span
tracer.method_span
tracer.rollback_span
tracer.activity_span
```

Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>