### PR TITLE
Add error=true tag when activity failed or hypothesis has deviated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-opentracing/compare/0.1.2...HEAD
 
+### Added
+
+-   Marked with `error:true` deviated hypotheses and failed activities
+
 ## [0.1.2][] - 2018-12-06
 
 [0.1.2]: https://github.com/chaostoolkit-incubator/chaostoolkit-opentracing/compare/0.1.1...0.1.2

--- a/chaostracing/control.py
+++ b/chaostracing/control.py
@@ -132,6 +132,7 @@ def after_hypothesis_control(context: Hypothesis, state: Dict[str, Any],
         span.set_tag('deviated', deviated)
         if deviated and "probes" in state:
             deviated_probe = state["probes"][-1]
+            span.set_tag("error", True)
             span.log_kv({
                 "probe": deviated_probe["activity"]["name"],
                 "expected": deviated_probe["activity"]["tolerance"],
@@ -241,6 +242,7 @@ def after_activity_control(context: Activity, state: Run, **kwargs):
         status = state.get("status")
         span.set_tag('status', status)
         if status == "failed":
+            span.set_tag("error", True)
             span.log_kv({
                 "event": "error",
                 "stack": state["exception"]
@@ -249,6 +251,7 @@ def after_activity_control(context: Activity, state: Run, **kwargs):
         tolerance_met = state.get("tolerance_met")
         if tolerance_met is not None:
             span.set_tag('deviated', 1 if tolerance_met else 0)
+            span.set_tag('error', True if tolerance_met else False)
 
         span.finish()
     finally:


### PR DESCRIPTION
Closes https://github.com/chaostoolkit-incubator/chaostoolkit-opentracing/issues/2

- [x] Set `error:True` for deviated hypotheses
- [x] Set `error:True` for failed activities

Not sure if experiment span needs to be marked with `error:True` if `status != completed` :confused: 

Using this PR an activity span that failed will look like this:
![span_with_error](https://user-images.githubusercontent.com/4560173/59691233-962de900-91da-11e9-9dc0-36d51698a3c9.png)
