### PR TITLE
Enrich span names in OTEL traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-opentracing/compare/0.16.1..HEAD
 
+### Fixed
+
+- Added the ctk activity name in activity spans to enrich the user readability in backend tracing systems. [#5][ctk-opentracing-5]
+
+[ctk-opentracing-5]: https://github.com/chaostoolkit-incubator/chaostoolkit-opentracing/issues/5
 
 ## [0.16.1][] - 2023-12-18
 

--- a/chaostracing/oltp.py
+++ b/chaostracing/oltp.py
@@ -236,7 +236,7 @@ class OLTPRunEventHandler(RunEventHandler):
                     f"activity: {activity_name}", span, start_time=child_start_ts, end_on_exit=False
                 ) as child:
                     activity = probe["activity"]
-                    child.set_attribute("chaostoolkit.activity.name", activity["name"])
+                    child.set_attribute("chaostoolkit.activity.name", activity_name)
                     child.set_attribute(
                         "chaostoolkit.activity.background",
                         activity.get("background", False),

--- a/chaostracing/oltp.py
+++ b/chaostracing/oltp.py
@@ -233,7 +233,10 @@ class OLTPRunEventHandler(RunEventHandler):
                 )
                 activity_name: str = probe["activity"]["name"]
                 with new_span(
-                    f"activity: {activity_name}", span, start_time=child_start_ts, end_on_exit=False
+                    f"activity: {activity_name}",
+                    span,
+                    start_time=child_start_ts,
+                    end_on_exit=False,
                 ) as child:
                     activity = probe["activity"]
                     child.set_attribute("chaostoolkit.activity.name", activity_name)

--- a/chaostracing/oltp.py
+++ b/chaostracing/oltp.py
@@ -231,8 +231,9 @@ class OLTPRunEventHandler(RunEventHandler):
                     .timestamp()
                     * 1e9
                 )
+                activity_name: str = probe["activity"]["name"]
                 with new_span(
-                    "activity", span, start_time=child_start_ts, end_on_exit=False
+                    f"activity: {activity_name}", span, start_time=child_start_ts, end_on_exit=False
                 ) as child:
                     activity = probe["activity"]
                     child.set_attribute("chaostoolkit.activity.name", activity["name"])
@@ -330,13 +331,14 @@ class OLTPRunEventHandler(RunEventHandler):
 
     def start_activity(self, activity: Activity) -> None:
         parent = self.current_span
+        activity_name: str = activity.get("name")
         if self.continuous_span is not None:
             if "tolerance" in activity:
                 return
 
         stack = ExitStack()
-        span = stack.enter_context(new_span("activity", parent))
-        span.set_attribute("chaostoolkit.activity.name", activity.get("name"))
+        span = stack.enter_context(new_span(f"activity: {activity_name}", parent))
+        span.set_attribute("chaostoolkit.activity.name", activity_name)
         span.set_attribute(
             "chaostoolkit.activity.background", activity.get("background", False)
         )


### PR DESCRIPTION
This PR is to address #5 and enrich the trace view for users in their chosen backend by adding the actual activity name as part of the spans name.